### PR TITLE
feat(dali-center): add switch platform and sensor enable/disable support

### DIFF
--- a/custom_components/dali_center/const.py
+++ b/custom_components/dali_center/const.py
@@ -1,3 +1,4 @@
 """Constants for the Dali Center integration."""
 
 DOMAIN = "dali_center"
+MANUFACTURER = "Sunricher"

--- a/custom_components/dali_center/event.py
+++ b/custom_components/dali_center/event.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from PySrDaliGateway import DaliGateway, Device
 from PySrDaliGateway.helper import is_panel_device
 from PySrDaliGateway.const import BUTTON_EVENTS
@@ -89,7 +89,7 @@ class DaliCenterPanelEvent(EventEntity):
         return {
             "identifiers": {(DOMAIN, self._device_id)},
             "name": self._device.name,
-            "manufacturer": "Dali Center",
+            "manufacturer": MANUFACTURER,
             "model": f"Panel Type {self._device.dev_type}",
             "via_device": (DOMAIN, self._device.gw_sn),
         }

--- a/custom_components/dali_center/light.py
+++ b/custom_components/dali_center/light.py
@@ -19,7 +19,7 @@ from homeassistant.components.light import (
     ATTR_HS_COLOR,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER
 from PySrDaliGateway import DaliGateway, Device, Group
 from PySrDaliGateway.helper import is_light_device
 
@@ -114,7 +114,7 @@ class DaliCenterLight(LightEntity):
         return {
             "identifiers": {(DOMAIN, self._unique_id)},
             "name": self._light.name,
-            "manufacturer": "Dali Center",
+            "manufacturer": MANUFACTURER,
             "model": f"Dali Light Type {self._light.dev_type}",
             "via_device": (DOMAIN, self._light.gw_sn),
         }

--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/maginawin/ha-dali-center/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "PySrDaliGateway>=0.1.4"
+    "PySrDaliGateway>=0.2.1"
   ],
   "ssdp": [],
   "version": "0.1.2",

--- a/custom_components/dali_center/switch.py
+++ b/custom_components/dali_center/switch.py
@@ -1,0 +1,190 @@
+"""Platform for Dali Center illuminance sensor enable/disable switches."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, MANUFACTURER
+from PySrDaliGateway import DaliGateway, Device
+from PySrDaliGateway.helper import is_illuminance_sensor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Dali Center illuminance sensor enable/disable switches."""
+
+    gateway: DaliGateway = hass.data[DOMAIN][entry.entry_id]
+    devices: list[Device] = [
+        Device(gateway, device)
+        for device in entry.data.get("devices", [])
+    ]
+
+    _LOGGER.debug(
+        "Processing initially for illuminance sensor switches: %s",
+        devices
+    )
+
+    added_devices = set()
+    new_switches: list[SwitchEntity] = []
+    for device in devices:
+        if device.dev_id in added_devices:
+            continue
+
+        # Only create switches for illuminance sensor devices
+        if is_illuminance_sensor(device.dev_type):
+            new_switches.append(
+                DaliCenterIlluminanceSensorEnableSwitch(device))
+            added_devices.add(device.dev_id)
+
+    if new_switches:
+        async_add_entities(new_switches)
+
+
+class DaliCenterIlluminanceSensorEnableSwitch(SwitchEntity):
+    """Representation of an Illuminance Sensor Enable/Disable Switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(self, device: Device) -> None:
+        """Initialize the illuminance sensor enable switch."""
+        self._device = device
+        self._name = "Sensor Enable"
+        self._unique_id = f"{device.unique_id}_sensor_enable"
+        self._device_id = device.unique_id
+        self._available = device.status == "online"
+        self._is_on: bool = True  # Default to enabled
+
+        # Initialize current sensor enable state by querying gateway
+        self._sync_sensor_state()
+
+    def _sync_sensor_state(self) -> None:
+        """Sync sensor enable state from gateway."""
+        try:
+            # Query current sensor enable state using the new command
+            self._device.get_sensor_enabled()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug(
+                "Could not sync sensor state for device %s: %s",
+                self._device_id, e
+            )
+
+    @property
+    def name(self) -> str:
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID of the switch."""
+        return self._unique_id
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._device.name,
+            "manufacturer": MANUFACTURER,
+            "model": f"Illuminance Sensor Type {self._device.dev_type}",
+            "via_device": (DOMAIN, self._device.gw_sn),
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if the switch is available."""
+        return self._available
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the illuminance sensor is enabled."""
+        return self._is_on
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the switch."""
+        return "mdi:brightness-6"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the illuminance sensor (enable it)."""
+        try:
+            self._device.set_sensor_enabled(True)
+            self._is_on = True
+            self.async_write_ha_state()
+            _LOGGER.debug(
+                "Enabled illuminance sensor for device %s (%s)",
+                self._device.name, self._device_id
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.error(
+                "Failed to enable illuminance sensor for device %s: %s",
+                self._device_id, e
+            )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the illuminance sensor (disable it)."""
+        try:
+            self._device.set_sensor_enabled(False)
+            self._is_on = False
+            self.async_write_ha_state()
+            _LOGGER.debug(
+                "Disabled illuminance sensor for device %s (%s)",
+                self._device.name, self._device_id
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.error(
+                "Failed to disable illuminance sensor for device %s: %s",
+                self._device_id, e
+            )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to sensor on/off state updates."""
+        # Listen for availability updates
+        signal = f"dali_center_update_available_{self._device_id}"
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, signal, self._handle_device_update_available
+            )
+        )
+
+        # Listen for sensor on/off state updates
+        signal = f"dali_center_sensor_on_off_{self._device_id}"
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, signal, self._handle_sensor_on_off_update
+            )
+        )
+
+        # Sync initial state
+        self._sync_sensor_state()
+
+    def _handle_device_update_available(self, available: bool) -> None:
+        """Handle device availability updates."""
+        self._available = available
+        self.hass.loop.call_soon_threadsafe(
+            self.schedule_update_ha_state
+        )
+
+    def _handle_sensor_on_off_update(self, on_off: bool) -> None:
+        """Handle sensor on/off state updates from gateway."""
+        self._is_on = on_off
+        _LOGGER.warning(
+            "Illuminance sensor enable state for device %s updated to: %s",
+            self._device_id, on_off
+        )
+        self.hass.loop.call_soon_threadsafe(
+            self.schedule_update_ha_state
+        )


### PR DESCRIPTION
    • Added support for the `SWITCH` platform in the integration to manage on/off states.
    • Introduced handling for sensor enable/disable states with `on_sensor_on_off` callback and related logic in `IlluminanceSensor`.
    • Enhanced gateway setup with TLS status check and improved device naming based on security status.
    • Updated manufacturer name to "Sunricher" across all entities for consistency.
    • Bumped dependency version for `PySrDaliGateway` to `>=0.2.1` to support new features.
    • Added version information retrieval during setup with software and hardware version details for the gateway device.
    • Improved error handling for initial sensor state queries and gateway version fetching.