### PR TITLE
feat: Add All Lights control entity for gateway broadcast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,8 @@ Detailed explanation of changes (if necessary)
 - `docs(readme): update installation instructions`
 - `chore(release): bump version to 0.2.0`
 
+**IMPORTANT**: Do not include Claude Code signatures, co-author attributions, or AI-generated markers in commit messages. Keep commits clean and focused on the technical changes.
+
 ### Pull Request Process
 
 1. **Create feature branch** from main branch

--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -13,7 +13,7 @@
   "issue_tracker": "https://github.com/maginawin/ha-dali-center/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "PySrDaliGateway==0.6.2"
+    "PySrDaliGateway==0.6.4"
   ],
   "ssdp": [],
   "version": "0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "homeassistant>=2023.1.0",
     "async_timeout>=4.0.0",
     "voluptuous",
-    "PySrDaliGateway==0.6.2",
+    "PySrDaliGateway==0.6.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,9 @@ class MockDaliGateway:
                     setattr(device, key, value)
                 break
 
-    def command_write_dev(self, dev_type: str, channel: int, address: int, properties: list) -> None:
+    def command_write_dev(
+        self, dev_type: str, channel: int, address: int, properties: list
+    ) -> None:
         """Mock command_write_dev method for broadcast commands."""
         # Mock implementation - doesn't actually send commands
         # In tests, we just verify this method is called correctly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,12 @@ class MockDaliGateway:
                     setattr(device, key, value)
                 break
 
+    def command_write_dev(self, dev_type: str, channel: int, address: int, properties: list) -> None:
+        """Mock command_write_dev method for broadcast commands."""
+        # Mock implementation - doesn't actually send commands
+        # In tests, we just verify this method is called correctly
+        pass
+
 
 class MockDaliGatewayDiscovery:
     """Mock DaliGatewayDiscovery class for testing."""

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -196,7 +196,7 @@ class TestDaliCenterAllLights:
         """Create mock gateway."""
         return MockDaliGateway()
 
-    @pytest.fixture  
+    @pytest.fixture
     def all_lights_entity(self, mock_gateway):
         """Create all lights entity for testing."""
         entity = DaliCenterAllLights(mock_gateway)
@@ -221,7 +221,7 @@ class TestDaliCenterAllLights:
         assert hasattr(all_lights_entity, "color_mode")
         assert hasattr(all_lights_entity, "min_color_temp_kelvin")
         assert hasattr(all_lights_entity, "max_color_temp_kelvin")
-        
+
         # Test color temperature range
         assert all_lights_entity.min_color_temp_kelvin == 1000
         assert all_lights_entity.max_color_temp_kelvin == 8000
@@ -238,8 +238,8 @@ class TestDaliCenterAllLights:
         hsv_string = all_lights_entity._rgbw_to_hsv_string((255, 0, 0))
         # Red should be hue=0, saturation=1000, value=1000
         assert hsv_string == "000003e803e8"
-        
-        # Test pure white (RGB: 255, 255, 255)  
+
+        # Test pure white (RGB: 255, 255, 255)
         hsv_string = all_lights_entity._rgbw_to_hsv_string((255, 255, 255))
         # White should be hue=0, saturation=0, value=1000
         assert hsv_string == "0000000003e8"
@@ -249,7 +249,7 @@ class TestDaliCenterAllLights:
         """Test basic turn on functionality."""
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             await all_lights_entity.async_turn_on()
-            
+
             # Should call command_write_dev with broadcast address
             mock_command.assert_called_once_with(
                 "FFFF", 0, 1, [{"dpid": 20, "dataType": "bool", "value": True}]
@@ -262,7 +262,7 @@ class TestDaliCenterAllLights:
         """Test turn on with brightness."""
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             await all_lights_entity.async_turn_on(brightness=128)
-            
+
             expected_data = [
                 {"dpid": 20, "dataType": "bool", "value": True},
                 {"dpid": 22, "dataType": "uint16", "value": 128},
@@ -275,7 +275,7 @@ class TestDaliCenterAllLights:
         """Test turn on with color temperature."""
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             await all_lights_entity.async_turn_on(color_temp_kelvin=3000)
-            
+
             expected_data = [
                 {"dpid": 20, "dataType": "bool", "value": True},
                 {"dpid": 23, "dataType": "uint16", "value": 3000},
@@ -289,38 +289,45 @@ class TestDaliCenterAllLights:
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             # Red color with white channel
             await all_lights_entity.async_turn_on(rgbw_color=(255, 0, 0, 100))
-            
+
             expected_data = [
                 {"dpid": 20, "dataType": "bool", "value": True},
-                {"dpid": 24, "dataType": "string", "value": "000003e803e8"},  # RGB to HSV
+                {
+                    "dpid": 24,
+                    "dataType": "string",
+                    "value": "000003e803e8",
+                },  # RGB to HSV
                 {"dpid": 21, "dataType": "uint8", "value": 100},  # White channel
             ]
             mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
             assert all_lights_entity.rgbw_color == (255, 0, 0, 100)
 
-    @pytest.mark.asyncio  
+    @pytest.mark.asyncio
     async def test_turn_on_with_hs_color(self, all_lights_entity, mock_gateway):
         """Test turn on with HS color."""
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             # Red color in HS format (hue=0, saturation=100)
             await all_lights_entity.async_turn_on(hs_color=(0, 100))
-            
+
             expected_data = [
                 {"dpid": 20, "dataType": "bool", "value": True},
-                {"dpid": 24, "dataType": "string", "value": "000003e803e8"},  # Converted to HSV
+                {
+                    "dpid": 24,
+                    "dataType": "string",
+                    "value": "000003e803e8",
+                },  # Converted to HSV
             ]
             mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
             assert all_lights_entity.hs_color == (0, 100)
 
     @pytest.mark.asyncio
     async def test_turn_on_multiple_parameters(self, all_lights_entity, mock_gateway):
-        """Test turn on with multiple parameters.""" 
+        """Test turn on with multiple parameters."""
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             await all_lights_entity.async_turn_on(
-                brightness=200, 
-                color_temp_kelvin=4000
+                brightness=200, color_temp_kelvin=4000
             )
-            
+
             expected_data = [
                 {"dpid": 20, "dataType": "bool", "value": True},
                 {"dpid": 22, "dataType": "uint16", "value": 200},
@@ -335,7 +342,7 @@ class TestDaliCenterAllLights:
         """Test turn off functionality."""
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             await all_lights_entity.async_turn_off()
-            
+
             expected_data = [{"dpid": 20, "dataType": "bool", "value": False}]
             mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
             assert all_lights_entity.is_on is False
@@ -346,56 +353,58 @@ class TestDaliCenterAllLights:
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             # Mock command to raise exception
             mock_command.side_effect = Exception("Gateway error")
-            
+
             # Should not raise exception
             await all_lights_entity.async_turn_on()
-            
+
             # State should not be updated on error
             assert all_lights_entity.is_on is False
 
-    @pytest.mark.asyncio  
+    @pytest.mark.asyncio
     async def test_turn_off_command_exception(self, all_lights_entity, mock_gateway):
         """Test turn off command exception handling."""
         # Set initial state to on
         all_lights_entity._attr_is_on = True
-        
+
         with patch.object(mock_gateway, "command_write_dev") as mock_command:
             mock_command.side_effect = Exception("Gateway error")
-            
+
             await all_lights_entity.async_turn_off()
-            
+
             # State should remain unchanged on error
             assert all_lights_entity.is_on is True
 
     @pytest.mark.asyncio
     async def test_setup_entry_includes_all_lights(self):
-        """Test that setup entry includes the All Lights entity.""" 
+        """Test that setup entry includes the All Lights entity."""
         # Create fixtures locally
         mock_hass = Mock(spec=HomeAssistant)
-        
+
         gateway = MockDaliGateway()
         mock_config_entry = Mock()
         mock_config_entry.runtime_data = Mock()
         mock_config_entry.runtime_data.gateway = gateway
         mock_config_entry.data = {
             "devices": [{"sn": "light001", "dev_type": "1"}],
-            "groups": []
+            "groups": [],
         }
-        
+
         mock_add_entities = Mock(spec=AddEntitiesCallback)
-        
+
         # Call setup
         await async_setup_entry(mock_hass, mock_config_entry, mock_add_entities)
-        
+
         # Should be called at least once
         assert mock_add_entities.call_count >= 1
-        
+
         # Get all entities from all calls
         all_entities = []
         for call in mock_add_entities.call_args_list:
             all_entities.extend(call[0][0])
-        
+
         # Should have at least one All Lights entity
-        all_lights_entities = [e for e in all_entities if isinstance(e, DaliCenterAllLights)]
+        all_lights_entities = [
+            e for e in all_entities if isinstance(e, DaliCenterAllLights)
+        ]
         assert len(all_lights_entities) == 1
         assert all_lights_entities[0].name == "All Lights"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from custom_components.dali_center.light import DaliCenterLight, async_setup_entry
+from custom_components.dali_center.light import (
+    DaliCenterAllLights,
+    DaliCenterLight,
+    async_setup_entry,
+)
 from custom_components.dali_center.types import DaliCenterData
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -182,3 +186,216 @@ class TestDaliCenterLight:
 
             # Should call device's turn_off method
             mock_turn_off.assert_called_once()
+
+
+class TestDaliCenterAllLights:
+    """Test the DaliCenterAllLights class."""
+
+    @pytest.fixture
+    def mock_gateway(self):
+        """Create mock gateway."""
+        return MockDaliGateway()
+
+    @pytest.fixture  
+    def all_lights_entity(self, mock_gateway):
+        """Create all lights entity for testing."""
+        entity = DaliCenterAllLights(mock_gateway)
+        # Mock hass to prevent AttributeError
+        entity.hass = Mock()
+        entity.hass.loop = Mock()
+        entity.hass.loop.call_soon_threadsafe = Mock()
+        return entity
+
+    def test_all_lights_initialization(self, all_lights_entity, mock_gateway):
+        """Test all lights entity initialization."""
+        assert all_lights_entity.name == "All Lights"
+        assert all_lights_entity.unique_id == f"{mock_gateway.gw_sn}_all_lights"
+        assert all_lights_entity.available is True
+        assert all_lights_entity.icon == "mdi:lightbulb-group-outline"
+        assert all_lights_entity.is_on is False
+
+    def test_all_lights_properties(self, all_lights_entity):
+        """Test all lights entity properties."""
+        # Test color mode properties
+        assert hasattr(all_lights_entity, "supported_color_modes")
+        assert hasattr(all_lights_entity, "color_mode")
+        assert hasattr(all_lights_entity, "min_color_temp_kelvin")
+        assert hasattr(all_lights_entity, "max_color_temp_kelvin")
+        
+        # Test color temperature range
+        assert all_lights_entity.min_color_temp_kelvin == 1000
+        assert all_lights_entity.max_color_temp_kelvin == 8000
+
+    def test_all_lights_device_info(self, all_lights_entity, mock_gateway):
+        """Test all lights device info."""
+        device_info = all_lights_entity.device_info
+        assert device_info is not None
+        assert device_info["identifiers"] == {("dali_center", mock_gateway.gw_sn)}
+
+    def test_rgbw_to_hsv_string_conversion(self, all_lights_entity):
+        """Test RGB to HSV string conversion."""
+        # Test pure red (RGB: 255, 0, 0)
+        hsv_string = all_lights_entity._rgbw_to_hsv_string((255, 0, 0))
+        # Red should be hue=0, saturation=1000, value=1000
+        assert hsv_string == "000003e803e8"
+        
+        # Test pure white (RGB: 255, 255, 255)  
+        hsv_string = all_lights_entity._rgbw_to_hsv_string((255, 255, 255))
+        # White should be hue=0, saturation=0, value=1000
+        assert hsv_string == "0000000003e8"
+
+    @pytest.mark.asyncio
+    async def test_turn_on_basic(self, all_lights_entity, mock_gateway):
+        """Test basic turn on functionality."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            await all_lights_entity.async_turn_on()
+            
+            # Should call command_write_dev with broadcast address
+            mock_command.assert_called_once_with(
+                "FFFF", 0, 1, [{"dpid": 20, "dataType": "bool", "value": True}]
+            )
+            # State should be updated
+            assert all_lights_entity.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_turn_on_with_brightness(self, all_lights_entity, mock_gateway):
+        """Test turn on with brightness."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            await all_lights_entity.async_turn_on(brightness=128)
+            
+            expected_data = [
+                {"dpid": 20, "dataType": "bool", "value": True},
+                {"dpid": 22, "dataType": "uint16", "value": 128},
+            ]
+            mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
+            assert all_lights_entity.brightness == 128
+
+    @pytest.mark.asyncio
+    async def test_turn_on_with_color_temp(self, all_lights_entity, mock_gateway):
+        """Test turn on with color temperature."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            await all_lights_entity.async_turn_on(color_temp_kelvin=3000)
+            
+            expected_data = [
+                {"dpid": 20, "dataType": "bool", "value": True},
+                {"dpid": 23, "dataType": "uint16", "value": 3000},
+            ]
+            mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
+            assert all_lights_entity.color_temp_kelvin == 3000
+
+    @pytest.mark.asyncio
+    async def test_turn_on_with_rgbw_color(self, all_lights_entity, mock_gateway):
+        """Test turn on with RGBW color."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            # Red color with white channel
+            await all_lights_entity.async_turn_on(rgbw_color=(255, 0, 0, 100))
+            
+            expected_data = [
+                {"dpid": 20, "dataType": "bool", "value": True},
+                {"dpid": 24, "dataType": "string", "value": "000003e803e8"},  # RGB to HSV
+                {"dpid": 21, "dataType": "uint8", "value": 100},  # White channel
+            ]
+            mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
+            assert all_lights_entity.rgbw_color == (255, 0, 0, 100)
+
+    @pytest.mark.asyncio  
+    async def test_turn_on_with_hs_color(self, all_lights_entity, mock_gateway):
+        """Test turn on with HS color."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            # Red color in HS format (hue=0, saturation=100)
+            await all_lights_entity.async_turn_on(hs_color=(0, 100))
+            
+            expected_data = [
+                {"dpid": 20, "dataType": "bool", "value": True},
+                {"dpid": 24, "dataType": "string", "value": "000003e803e8"},  # Converted to HSV
+            ]
+            mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
+            assert all_lights_entity.hs_color == (0, 100)
+
+    @pytest.mark.asyncio
+    async def test_turn_on_multiple_parameters(self, all_lights_entity, mock_gateway):
+        """Test turn on with multiple parameters.""" 
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            await all_lights_entity.async_turn_on(
+                brightness=200, 
+                color_temp_kelvin=4000
+            )
+            
+            expected_data = [
+                {"dpid": 20, "dataType": "bool", "value": True},
+                {"dpid": 22, "dataType": "uint16", "value": 200},
+                {"dpid": 23, "dataType": "uint16", "value": 4000},
+            ]
+            mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
+            assert all_lights_entity.brightness == 200
+            assert all_lights_entity.color_temp_kelvin == 4000
+
+    @pytest.mark.asyncio
+    async def test_turn_off(self, all_lights_entity, mock_gateway):
+        """Test turn off functionality."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            await all_lights_entity.async_turn_off()
+            
+            expected_data = [{"dpid": 20, "dataType": "bool", "value": False}]
+            mock_command.assert_called_once_with("FFFF", 0, 1, expected_data)
+            assert all_lights_entity.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_turn_on_command_exception(self, all_lights_entity, mock_gateway):
+        """Test turn on command exception handling."""
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            # Mock command to raise exception
+            mock_command.side_effect = Exception("Gateway error")
+            
+            # Should not raise exception
+            await all_lights_entity.async_turn_on()
+            
+            # State should not be updated on error
+            assert all_lights_entity.is_on is False
+
+    @pytest.mark.asyncio  
+    async def test_turn_off_command_exception(self, all_lights_entity, mock_gateway):
+        """Test turn off command exception handling."""
+        # Set initial state to on
+        all_lights_entity._attr_is_on = True
+        
+        with patch.object(mock_gateway, "command_write_dev") as mock_command:
+            mock_command.side_effect = Exception("Gateway error")
+            
+            await all_lights_entity.async_turn_off()
+            
+            # State should remain unchanged on error
+            assert all_lights_entity.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_includes_all_lights(self):
+        """Test that setup entry includes the All Lights entity.""" 
+        # Create fixtures locally
+        mock_hass = Mock(spec=HomeAssistant)
+        
+        gateway = MockDaliGateway()
+        mock_config_entry = Mock()
+        mock_config_entry.runtime_data = Mock()
+        mock_config_entry.runtime_data.gateway = gateway
+        mock_config_entry.data = {
+            "devices": [{"sn": "light001", "dev_type": "1"}],
+            "groups": []
+        }
+        
+        mock_add_entities = Mock(spec=AddEntitiesCallback)
+        
+        # Call setup
+        await async_setup_entry(mock_hass, mock_config_entry, mock_add_entities)
+        
+        # Should be called at least once
+        assert mock_add_entities.call_count >= 1
+        
+        # Get all entities from all calls
+        all_entities = []
+        for call in mock_add_entities.call_args_list:
+            all_entities.extend(call[0][0])
+        
+        # Should have at least one All Lights entity
+        all_lights_entities = [e for e in all_entities if isinstance(e, DaliCenterAllLights)]
+        assert len(all_lights_entities) == 1
+        assert all_lights_entities[0].name == "All Lights"


### PR DESCRIPTION
## Summary

- Add `DaliCenterAllLights` entity for comprehensive control of all DALI devices
- Supports broadcast commands via FFFF address to control all lights simultaneously  
- Implements all Group-level capabilities: on/off, brightness, color temperature, RGBW color control
- Updates PySrDaliGateway dependency from 0.6.2 to 0.6.4 for compatibility

## Features

### Control Capabilities
- **Basic Control**: On/off functionality (DPID 20)
- **Brightness Control**: 0-255 range brightness adjustment (DPID 22)
- **Color Temperature**: Kelvin-based color temperature control (DPID 23) 
- **RGBW Color Control**: Full color and white channel control (DPID 24 + 21)
- **HS Color Space**: Automatic conversion from HS to RGBW format

### Technical Implementation
- **Entity Name**: "All Lights" (following Hue integration naming convention)
- **Unique ID**: `{gateway_sn}_all_lights`
- **Broadcast Address**: "FFFF" to target all devices
- **State Management**: Local state simulation (no feedback from broadcast commands)
- **Error Handling**: Comprehensive exception handling with logging

### Integration
- Automatically added to Light platform during setup
- Associated with gateway device in Home Assistant device registry
- Uses existing `gateway.command_write_dev()` method for command execution

### Dependencies
- Updated `PySrDaliGateway` from 0.6.2 to 0.6.4 in both `manifest.json` and `pyproject.toml`
- Ensures compatibility with all broadcast command features

## Test Plan

- [x] Entity appears in Home Assistant Light platform
- [x] Basic on/off functionality works
- [x] Brightness control functions correctly  
- [x] Color temperature adjustment works
- [x] RGBW color control operates properly
- [ ] Error handling works when gateway is offline
- [ ] State updates correctly in UI

## Code Quality

- ✅ Type hints throughout
- ✅ Proper exception handling  
- ✅ Comprehensive docstrings
- ✅ Code formatting with ruff
- ✅ No linting issues

## Example

<img width="384" height="100" alt="image" src="https://github.com/user-attachments/assets/f242cae7-c9b8-40af-9e4f-a2bc07e823f6" />
<img width="562" height="747" alt="image" src="https://github.com/user-attachments/assets/3ee3196a-c3cc-470e-99a9-063e0b946882" />
<img width="822" height="423" alt="image" src="https://github.com/user-attachments/assets/3034adba-279b-41b1-a39c-6588743e7969" />
