### PR TITLE
feat: add gateway restart button

### DIFF
--- a/custom_components/dali_center/button.py
+++ b/custom_components/dali_center/button.py
@@ -33,6 +33,8 @@ async def async_setup_entry(
 
     new_entities: list[ButtonEntity] = []
 
+    new_entities.append(DaliCenterGatewayRestartButton(gateway))
+
     for scene in scenes:
         if scene.scene_id in added_scenes:
             continue
@@ -67,3 +69,29 @@ class DaliCenterSceneButton(GatewayAvailabilityMixin, ButtonEntity):
         """Handle button press to activate scene."""
         _LOGGER.debug("Activating scene %s", self._scene.scene_id)
         self._scene.activate()
+
+
+class DaliCenterGatewayRestartButton(GatewayAvailabilityMixin, ButtonEntity):
+    """Representation of a Dali Center Gateway Restart Button."""
+
+    def __init__(self, gateway: DaliGateway) -> None:
+        """Initialize the gateway restart button."""
+        GatewayAvailabilityMixin.__init__(self, gateway.gw_sn)
+        ButtonEntity.__init__(self)
+
+        self._gateway = gateway
+        self._attr_name = f"{gateway.name} Restart"
+        self._attr_unique_id = f"{gateway.gw_sn}_restart"
+        self._attr_icon = "mdi:restart"
+
+    @cached_property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the gateway restart button."""
+        return {
+            "identifiers": {(DOMAIN, self._gateway.gw_sn)},
+        }
+
+    async def async_press(self) -> None:
+        """Handle button press to restart gateway."""
+        _LOGGER.info("Restarting gateway %s", self._gateway.gw_sn)
+        self._gateway.restart_gateway()

--- a/custom_components/dali_center/button.py
+++ b/custom_components/dali_center/button.py
@@ -6,6 +6,7 @@ from propcache.api import cached_property
 from PySrDaliGateway import DaliGateway, Scene
 
 from homeassistant.components.button import ButtonEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -83,6 +84,7 @@ class DaliCenterGatewayRestartButton(GatewayAvailabilityMixin, ButtonEntity):
         self._attr_name = f"{gateway.name} Restart"
         self._attr_unique_id = f"{gateway.gw_sn}_restart"
         self._attr_icon = "mdi:restart"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @cached_property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -13,7 +13,7 @@
   "issue_tracker": "https://github.com/maginawin/ha-dali-center/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "PySrDaliGateway==0.9.0"
+    "PySrDaliGateway==0.10.0"
   ],
   "ssdp": [],
   "version": "0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "homeassistant>=2023.1.0",
     "async_timeout>=4.0.0",
     "voluptuous",
-    "PySrDaliGateway==0.9.0",
+    "PySrDaliGateway==0.10.0",
 ]
 
 [project.optional-dependencies]
@@ -153,4 +153,3 @@ disallow_untyped_decorators = false
 disallow_untyped_defs = false
 warn_return_any = false
 warn_unreachable = false
-


### PR DESCRIPTION
## Summary
- Add gateway restart functionality as a diagnostic button entity
- Update PySrDaliGateway dependency to v0.10.0 to support restart feature
- Create DaliCenterGatewayRestartButton with proper device association and diagnostic categorization

## Changes Made
- **Button Platform**: Added `DaliCenterGatewayRestartButton` class in `button.py`
  - Implements restart functionality through PySrDaliGateway's `restart_gateway()` method
  - Uses diagnostic entity category for proper UI placement
  - Includes restart icon (`mdi:restart`) and proper device association
- **Dependencies**: Updated PySrDaliGateway from v0.9.0 to v0.10.0 in both manifest.json and pyproject.toml
- **Entity Registration**: Gateway restart button is now automatically created for each gateway

## Test Plan
- [x] Verify gateway restart button appears in Home Assistant UI under diagnostic entities
- [x] Test button press triggers gateway restart functionality
- [x] Confirm button is properly associated with gateway device
- [x] Validate dependency update works correctly with new PySrDaliGateway version

## Example

<img width="1073" height="1150" alt="CleanShot 2025-09-10 at 15 13 48" src="https://github.com/user-attachments/assets/ff4d6310-8161-41a9-83c0-952ef811b1b5" />