### PR TITLE
fix: update PySrDaliGateway to 0.11.1 for HA MQTT compatibility

### DIFF
--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -13,7 +13,7 @@
   "issue_tracker": "https://github.com/maginawin/ha-dali-center/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "PySrDaliGateway==0.11.0"
+    "PySrDaliGateway==0.11.1"
   ],
   "ssdp": [],
   "version": "0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "homeassistant>=2023.1.0",
     "async_timeout>=4.0.0",
     "voluptuous",
-    "PySrDaliGateway==0.11.0",
+    "PySrDaliGateway==0.11.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Updated PySrDaliGateway from 0.11.0 to 0.11.1
- Resolves MQTT dependency conflicts across different Home Assistant versions
- Ensures compatibility with both paho-mqtt 1.6.x (HA 2024.x) and 2.x (HA 2025.x)

## Problem
Users were unable to install the integration on Home Assistant 2024.12.5 due to paho-mqtt version conflicts. The integration required paho-mqtt>=2.0.0 while HA 2024.x ships with paho-mqtt==1.6.1.

## Solution
The updated PySrDaliGateway 0.11.1 includes compatibility fixes that allow it to work with both paho-mqtt version series, ensuring the integration can be installed on both HA 2024.x and 2025.x releases.

## Test Plan
- [x] Install on Home Assistant 2024.12.5 (with paho-mqtt 1.6.1)
- [x] Install on Home Assistant 2025.x (with paho-mqtt 2.x)
- [x] Verify gateway discovery and connection works
- [x] Test device control functionality

Fixes #29