### PR TITLE
feat: migrate scenes to native Home Assistant scene platform

### DIFF
--- a/custom_components/dali_center/__init__.py
+++ b/custom_components/dali_center/__init__.py
@@ -24,6 +24,7 @@ _PLATFORMS: list[Platform] = [
     Platform.BUTTON,
     Platform.EVENT,
     Platform.SWITCH,
+    Platform.SCENE,
 ]
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/dali_center/button.py
+++ b/custom_components/dali_center/button.py
@@ -1,9 +1,9 @@
-"""Support for Dali Center Scene Buttons."""
+"""Support for Dali Center Gateway Control Buttons."""
 
 import logging
 
 from propcache.api import cached_property
-from PySrDaliGateway import DaliGateway, DaliGatewayType, Scene
+from PySrDaliGateway import DaliGateway
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
@@ -24,52 +24,11 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Dali Center button entities from config entry."""
-    added_scenes: set[int] = set()
     gateway: DaliGateway = entry.runtime_data.gateway
 
-    scenes: list[Scene] = [
-        Scene(gateway, scene) for scene in entry.data.get("scenes", [])
-    ]
-    _LOGGER.debug("Setting up button platform: %d scenes", len(scenes))
+    _LOGGER.debug("Setting up button platform for gateway %s", gateway.gw_sn)
 
-    new_entities: list[ButtonEntity] = []
-
-    new_entities.append(DaliCenterGatewayRestartButton(gateway))
-
-    for scene in scenes:
-        if scene.scene_id in added_scenes:
-            continue
-
-        new_entities.append(DaliCenterSceneButton(scene, gateway.to_dict()))
-        added_scenes.add(scene.scene_id)
-
-    if new_entities:
-        async_add_entities(new_entities)
-
-
-class DaliCenterSceneButton(GatewayAvailabilityMixin, ButtonEntity):
-    """Representation of a Dali Center Scene Button."""
-
-    def __init__(self, scene: Scene, gateway: DaliGatewayType) -> None:
-        """Initialize the scene button."""
-        GatewayAvailabilityMixin.__init__(self, scene.gw_sn, gateway)
-        ButtonEntity.__init__(self)
-
-        self._scene = scene
-        self._attr_name = f"{scene.name}"
-        self._attr_unique_id = scene.unique_id
-
-    @cached_property
-    def device_info(self) -> DeviceInfo:
-        """Return device info for the scene button."""
-        return {
-            "identifiers": {(DOMAIN, self._scene.gw_sn)},
-        }
-
-    async def async_press(self) -> None:
-        """Handle button press to activate scene."""
-        _LOGGER.debug("Activating scene %s", self._scene.scene_id)
-        self._scene.activate()
+    async_add_entities([DaliCenterGatewayRestartButton(gateway)])
 
 
 class DaliCenterGatewayRestartButton(GatewayAvailabilityMixin, ButtonEntity):

--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -13,7 +13,7 @@
   "issue_tracker": "https://github.com/maginawin/ha-dali-center/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "PySrDaliGateway==0.11.2"
+    "PySrDaliGateway==0.12.0"
   ],
   "ssdp": [],
   "version": "0.7.1",

--- a/custom_components/dali_center/scene.py
+++ b/custom_components/dali_center/scene.py
@@ -40,21 +40,21 @@ async def async_setup_entry(
         try:
             # Load scene details during setup
             scene_details = await gateway.read_scene(
-                scene.scene_id, getattr(scene, 'channel', 0)
+                scene.scene_id, getattr(scene, "channel", 0)
             )
             _LOGGER.debug(
                 "Loaded scene details for %s: %d devices",
                 scene.name,
-                len(scene_details.get("devices", []))
+                len(scene_details.get("devices", [])),
             )
 
             scene_entities.append(
                 DaliCenterScene(scene, gateway.to_dict(), scene_details)
             )
-        except (OSError, ValueError, KeyError) as exc:
-            _LOGGER.error(
-                "Failed to read scene details for %s: %s, skipping scene",
-                scene.name, exc
+        except (OSError, ValueError, KeyError):
+            _LOGGER.exception(
+                "Failed to read scene details for %s, skipping scene",
+                scene.name,
             )
 
     if scene_entities:
@@ -65,10 +65,7 @@ class DaliCenterScene(GatewayAvailabilityMixin, SceneEntity):
     """Representation of a DALI Center Scene."""
 
     def __init__(
-        self,
-        scene: Scene,
-        gateway: DaliGatewayType,
-        scene_details: SceneType
+        self, scene: Scene, gateway: DaliGatewayType, scene_details: SceneType
     ) -> None:
         """Initialize the DALI scene."""
         GatewayAvailabilityMixin.__init__(self, scene.gw_sn, gateway)
@@ -105,8 +102,7 @@ class DaliCenterScene(GatewayAvailabilityMixin, SceneEntity):
                 device["address"],
                 self._scene.gw_sn,
             )
-            entity_id = ent_reg.async_get_entity_id(
-                "light", DOMAIN, device_unique_id)
+            entity_id = ent_reg.async_get_entity_id("light", DOMAIN, device_unique_id)
 
             device_state: dict[str, Any] = {}
             if light_property := device["property"]:
@@ -116,7 +112,9 @@ class DaliCenterScene(GatewayAvailabilityMixin, SceneEntity):
                 if light_property["brightness"] is not None:
                     device_state["brightness"] = light_property["brightness"]
                 if light_property["color_temp_kelvin"] is not None:
-                    device_state["color_temp_kelvin"] = light_property["color_temp_kelvin"]
+                    device_state["color_temp_kelvin"] = light_property[
+                        "color_temp_kelvin"
+                    ]
                 if light_property["white_level"] is not None:
                     device_state["white_level"] = light_property["white_level"]
 
@@ -127,14 +125,16 @@ class DaliCenterScene(GatewayAvailabilityMixin, SceneEntity):
                     entity_states[entity_id] = device_state
 
             # Keep raw device info for debugging
-            raw_devices.append({
-                "address": device["address"],
-                "channel": device["channel"],
-                "device_type": device["dev_type"],
-                "device_unique_id": device_unique_id,
-                "entity_id": entity_id,
-                "mapped": entity_id is not None,
-            })
+            raw_devices.append(
+                {
+                    "address": device["address"],
+                    "channel": device["channel"],
+                    "device_type": device["dev_type"],
+                    "device_unique_id": device_unique_id,
+                    "entity_id": entity_id,
+                    "mapped": entity_id is not None,
+                }
+            )
 
         _LOGGER.warning(
             "Scene %s has %d devices, %d mapped to entities, %s",
@@ -149,7 +149,7 @@ class DaliCenterScene(GatewayAvailabilityMixin, SceneEntity):
                 "entity_ids": mapped_entities,
                 "device_count": len(raw_devices),
                 "devices": raw_devices,
-            }
+            },
         )
 
         return {

--- a/custom_components/dali_center/scene.py
+++ b/custom_components/dali_center/scene.py
@@ -1,0 +1,168 @@
+"""Support for DALI Center Scene entities."""
+
+import logging
+from typing import Any
+
+from propcache.api import cached_property
+from PySrDaliGateway import DaliGateway, DaliGatewayType, Scene, SceneType
+from PySrDaliGateway.helper import gen_device_unique_id
+
+from homeassistant.components.scene import Scene as SceneEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .entity import GatewayAvailabilityMixin
+from .types import DaliCenterConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DaliCenterConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up DALI Center scene entities from config entry."""
+    gateway: DaliGateway = entry.runtime_data.gateway
+
+    scenes: list[Scene] = [
+        Scene(gateway, scene) for scene in entry.data.get("scenes", [])
+    ]
+
+    _LOGGER.debug("Setting up scene platform with %d scenes", len(scenes))
+
+    # Pre-load scene details for all scenes
+    scene_entities: list[DaliCenterScene] = []
+    for scene in scenes:
+        try:
+            # Load scene details during setup
+            scene_details = await gateway.read_scene(
+                scene.scene_id, getattr(scene, 'channel', 0)
+            )
+            _LOGGER.debug(
+                "Loaded scene details for %s: %d devices",
+                scene.name,
+                len(scene_details.get("devices", []))
+            )
+
+            scene_entities.append(
+                DaliCenterScene(scene, gateway.to_dict(), scene_details)
+            )
+        except (OSError, ValueError, KeyError) as exc:
+            _LOGGER.error(
+                "Failed to read scene details for %s: %s, skipping scene",
+                scene.name, exc
+            )
+
+    if scene_entities:
+        async_add_entities(scene_entities)
+
+
+class DaliCenterScene(GatewayAvailabilityMixin, SceneEntity):
+    """Representation of a DALI Center Scene."""
+
+    def __init__(
+        self,
+        scene: Scene,
+        gateway: DaliGatewayType,
+        scene_details: SceneType
+    ) -> None:
+        """Initialize the DALI scene."""
+        GatewayAvailabilityMixin.__init__(self, scene.gw_sn, gateway)
+        SceneEntity.__init__(self)
+
+        self._scene = scene
+        self._attr_name = scene.name
+        self._attr_unique_id = scene.unique_id
+        self._scene_details = scene_details
+
+    @cached_property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the scene."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._scene.gw_sn)},
+        )
+
+    @cached_property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return scene device information as extra state attributes."""
+        # Get entity registry to map device unique_ids to actual entity_ids
+        ent_reg = er.async_get(self.hass)
+
+        # Build entity states map in HA standard format
+        entity_states: dict[str, dict[str, Any]] = {}
+        mapped_entities: list[str] = []
+        raw_devices: list[dict[str, Any]] = []
+
+        for device in self._scene_details["devices"]:
+            # Use SDK helper to generate correct unique_id
+            device_unique_id = gen_device_unique_id(
+                device["dev_type"],
+                device["channel"],
+                device["address"],
+                self._scene.gw_sn,
+            )
+            entity_id = ent_reg.async_get_entity_id(
+                "light", DOMAIN, device_unique_id)
+
+            device_state: dict[str, Any] = {}
+            if light_property := device["property"]:
+                # Map to HA light state format
+                if light_property["is_on"] is not None:
+                    device_state["state"] = "on" if light_property["is_on"] else "off"
+                if light_property["brightness"] is not None:
+                    device_state["brightness"] = light_property["brightness"]
+                if light_property["color_temp_kelvin"] is not None:
+                    device_state["color_temp_kelvin"] = light_property["color_temp_kelvin"]
+                if light_property["white_level"] is not None:
+                    device_state["white_level"] = light_property["white_level"]
+
+            # If we found a real entity_id, use it
+            if entity_id:
+                mapped_entities.append(entity_id)
+                if device_state:
+                    entity_states[entity_id] = device_state
+
+            # Keep raw device info for debugging
+            raw_devices.append({
+                "address": device["address"],
+                "channel": device["channel"],
+                "device_type": device["dev_type"],
+                "device_unique_id": device_unique_id,
+                "entity_id": entity_id,
+                "mapped": entity_id is not None,
+            })
+
+        _LOGGER.warning(
+            "Scene %s has %d devices, %d mapped to entities, %s",
+            self._attr_name,
+            len(raw_devices),
+            len(mapped_entities),
+            {
+                "scene_id": self._scene.scene_id,
+                "area_id": self._scene_details["area_id"],
+                "channel": self._scene_details["channel"],
+                "entity_states": entity_states,
+                "entity_ids": mapped_entities,
+                "device_count": len(raw_devices),
+                "devices": raw_devices,
+            }
+        )
+
+        return {
+            "scene_id": self._scene.scene_id,
+            "area_id": self._scene_details["area_id"],
+            "channel": self._scene_details["channel"],
+            "entity_states": entity_states,
+            "entity_ids": mapped_entities,
+            "device_count": len(raw_devices),
+            "devices": raw_devices,
+        }
+
+    async def async_activate(self, **kwargs: Any) -> None:
+        """Activate the DALI scene."""
+        _LOGGER.debug("Activating scene: %s", self._attr_name)
+        await self.hass.async_add_executor_job(self._scene.activate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-dali-center"
-version = "0.7.0"
+version = "0.7.1"
 description = "Home Assistant custom integration for Dali Center lighting control systems"
 authors = [{ name = "maginawin" }, { name = "niracler" }]
 requires-python = ">=3.13.0"
@@ -12,7 +12,7 @@ dependencies = [
     "homeassistant>=2023.1.0",
     "async_timeout>=4.0.0",
     "voluptuous",
-    "PySrDaliGateway==0.11.2",
+    "PySrDaliGateway==0.12.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Migrate scene functionality from button entities to native Home Assistant scene platform
- Implement proper scene entity with device state tracking and activation
- Add support for group devices in scene configurations

## Breaking Changes

⚠️ **Users need to manually refresh scenes in the integration options after updating** to migrate from button entities to native scene entities.

<img width="482" height="573" alt="image" src="https://github.com/user-attachments/assets/f6edca5d-2120-42c7-af17-c0df2a7d79d9" />

## Example

<img width="692" height="231" alt="image" src="https://github.com/user-attachments/assets/88ad686b-2032-44be-b59a-9dd9d48e4f22" />

<img width="590" height="564" alt="CleanShot 2025-09-19 at 14 11 47" src="https://github.com/user-attachments/assets/efa82dd6-ab98-42be-b253-57647deef344" />

## Test Plan

- [x] Scene entities appear correctly in Home Assistant
- [x] Scene activation works via `scene.activate` service
- [x] Device states are properly tracked in scene attributes
- [x] Group devices in scenes are handled correctly
- [x] Panel buttons continue to work without scenes
- [x] Existing configurations migrate smoothly