### PR TITLE
feat(config): add DHCP discovery support

### DIFF
--- a/custom_components/dali_center/config_flow.py
+++ b/custom_components/dali_center/config_flow.py
@@ -26,6 +26,8 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import CONF_SERIAL_NUMBER, DOMAIN
 
@@ -665,6 +667,18 @@ class DaliCenterConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
             },
         )
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery to update existing entries."""
+        mac_address = format_mac(discovery_info.macaddress)
+        serial_number = mac_address.replace(":", "").upper()
+
+        await self.async_set_unique_id(serial_number)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+
+        return self.async_abort(reason="unknown")
 
     def is_matching(self, other_flow: "ConfigFlow") -> bool:
         """Check if another flow is matching this one."""

--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -3,6 +3,11 @@
   "name": "Dali Center",
   "codeowners": ["@maginawin", "@niracler"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "registered_devices": true
+    }
+  ],
   "documentation": "https://github.com/maginawin/ha-dali-center/blob/main/README.md",
   "integration_type": "hub",
   "iot_class": "local_push",


### PR DESCRIPTION
## Summary

- Add DHCP discovery support to automatically detect and update Dali Center gateway IP addresses
- Implement `async_step_dhcp` method in config flow to handle DHCP discovery events
- Update IP addresses for existing entries when devices are rediscovered via DHCP

## Implementation Details

- Added DHCP service info imports in config flow
- Implemented DHCP discovery handler that:
  - Formats MAC address to serial number
  - Updates existing entries with new IP addresses
  - Aborts for unknown devices
- Registered DHCP discovery capability in manifest.json

## Test Plan

- [x] Verify DHCP discovery is registered correctly
- [x] Test IP address update for existing configured gateways
- [x] Confirm unknown devices are properly handled (aborted)
- [x] Validate MAC address formatting and serial number conversion