### PR TITLE
fix(event): remove redundant call_soon_threadsafe causing race condition

### DIFF
--- a/custom_components/dali_center/event.py
+++ b/custom_components/dali_center/event.py
@@ -94,6 +94,7 @@ class DaliCenterPanelEvent(EventEntity):
 
         self._panel.read_status()
 
+    @callback
     def _handle_device_update(self, status: PanelStatus) -> None:
         event_name = status["event_name"]
         event_type = status["event_type"]
@@ -105,23 +106,19 @@ class DaliCenterPanelEvent(EventEntity):
             self._panel.dev_id,
         )
 
-        @callback
-        def _fire_event() -> None:
-            event_data: dict[str, str | int] = {
-                "entity_id": self.entity_id,
-                "event_type": event_name,
-            }
+        event_data: dict[str, str | int] = {
+            "entity_id": self.entity_id,
+            "event_type": event_name,
+        }
 
-            if event_type == PanelEventType.ROTATE and rotate_value is not None:
-                event_data["rotate_value"] = rotate_value
-                self._trigger_event(event_name, {"rotate_value": rotate_value})
-            else:
-                self._trigger_event(event_name)
+        if event_type == PanelEventType.ROTATE and rotate_value is not None:
+            event_data["rotate_value"] = rotate_value
+            self._trigger_event(event_name, {"rotate_value": rotate_value})
+        else:
+            self._trigger_event(event_name)
 
-            self.hass.bus.async_fire(f"{DOMAIN}_event", event_data)
-            self.schedule_update_ha_state()
-
-        self.hass.loop.call_soon_threadsafe(_fire_event)
+        self.hass.bus.async_fire(f"{DOMAIN}_event", event_data)
+        self.schedule_update_ha_state()
 
     @callback
     def _handle_availability(self, available: bool) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dev = [
     "mypy>=1.16.0",
     "ruff>=0.12.1",
     "pre-commit",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -112,6 +114,7 @@ convention = "google"
 [tool.mypy]
 python_version = "3.13"
 platform = "linux"
+explicit_package_bases = true
 show_error_codes = true
 follow_imports = "normal"
 local_partial_types = true
@@ -144,6 +147,10 @@ warn_return_any = true
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
 module = "custom_components.dali_center.*"
 check_untyped_defs = false
 disallow_incomplete_defs = false
@@ -153,3 +160,11 @@ disallow_untyped_decorators = false
 disallow_untyped_defs = false
 warn_return_any = false
 warn_unreachable = false
+
+[tool.pyright]
+reportPrivateUsage = "none"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ha-dali-center integration."""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,130 @@
+"""Tests for the Dali Center event platform."""
+
+from unittest.mock import MagicMock, patch
+
+from PySrDaliGateway.types import PanelEventType, PanelStatus
+import pytest
+
+from custom_components.dali_center.event import DaliCenterPanelEvent
+
+
+@pytest.fixture
+def mock_panel() -> MagicMock:
+    """Create a mock Panel device."""
+    panel = MagicMock()
+    panel.dev_id = "test_device_123"
+    panel.name = "Test Panel"
+    panel.model = "Panel Model"
+    panel.gw_sn = "gateway_sn_123"
+    panel.status = "online"
+    panel.get_available_event_types.return_value = [
+        "button_1_press",
+        "button_2_press",
+    ]
+    return panel
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.loop = MagicMock()
+    hass.bus = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def panel_event(mock_panel: MagicMock, mock_hass: MagicMock) -> DaliCenterPanelEvent:
+    """Create a DaliCenterPanelEvent instance."""
+    event = DaliCenterPanelEvent(mock_panel)
+    event.hass = mock_hass
+    event.entity_id = "event.test_panel_buttons"
+    return event
+
+
+class TestDaliCenterPanelEvent:
+    """Test DaliCenterPanelEvent callback behavior."""
+
+    def test_handle_device_update_should_not_use_call_soon_threadsafe(
+        self, panel_event: DaliCenterPanelEvent, mock_hass: MagicMock
+    ) -> None:
+        """Test that _handle_device_update does not use redundant call_soon_threadsafe.
+
+        The callback is already dispatched to the event loop by PySrDaliGateway's
+        _dispatch_callback, so using call_soon_threadsafe again is redundant and
+        can cause race conditions during startup (Issue #63).
+        """
+        status: PanelStatus = {
+            "event_name": "button_1_press",
+            "key_no": 1,
+            "event_type": PanelEventType.PRESS,
+            "rotate_value": None,
+        }
+
+        with (
+            patch.object(panel_event, "_trigger_event") as mock_trigger,
+            patch.object(panel_event, "schedule_update_ha_state") as mock_schedule,
+        ):
+            panel_event._handle_device_update(status)  # noqa: SLF001
+
+            # CRITICAL: call_soon_threadsafe should NOT be called
+            # The buggy implementation calls it, causing the segfault
+            mock_hass.loop.call_soon_threadsafe.assert_not_called()
+
+            # _trigger_event should be called synchronously
+            mock_trigger.assert_called_once_with("button_1_press")
+
+            # schedule_update_ha_state should be called synchronously
+            mock_schedule.assert_called_once()
+
+    def test_handle_device_update_with_rotate_event(
+        self, panel_event: DaliCenterPanelEvent, mock_hass: MagicMock
+    ) -> None:
+        """Test _handle_device_update with rotate event includes rotate_value."""
+        status: PanelStatus = {
+            "event_name": "knob_rotate",
+            "key_no": 1,
+            "event_type": PanelEventType.ROTATE,
+            "rotate_value": 15,
+        }
+
+        with (
+            patch.object(panel_event, "_trigger_event") as mock_trigger,
+            patch.object(panel_event, "schedule_update_ha_state") as mock_schedule,
+        ):
+            panel_event._handle_device_update(status)  # noqa: SLF001
+
+            # Should NOT use call_soon_threadsafe
+            mock_hass.loop.call_soon_threadsafe.assert_not_called()
+
+            # _trigger_event should include rotate_value
+            mock_trigger.assert_called_once_with("knob_rotate", {"rotate_value": 15})
+
+            mock_schedule.assert_called_once()
+
+    def test_handle_device_update_fires_bus_event(
+        self, panel_event: DaliCenterPanelEvent, mock_hass: MagicMock
+    ) -> None:
+        """Test that _handle_device_update fires event on the bus."""
+        status: PanelStatus = {
+            "event_name": "button_1_press",
+            "key_no": 1,
+            "event_type": PanelEventType.PRESS,
+            "rotate_value": None,
+        }
+
+        with (
+            patch.object(panel_event, "_trigger_event"),
+            patch.object(panel_event, "schedule_update_ha_state"),
+        ):
+            panel_event._handle_device_update(status)  # noqa: SLF001
+
+            # Should NOT use call_soon_threadsafe
+            mock_hass.loop.call_soon_threadsafe.assert_not_called()
+
+            # Bus event should be fired synchronously
+            mock_hass.bus.async_fire.assert_called_once()
+            call_args = mock_hass.bus.async_fire.call_args
+            assert call_args[0][0] == "dali_center_event"
+            assert call_args[0][1]["entity_id"] == "event.test_panel_buttons"
+            assert call_args[0][1]["event_type"] == "button_1_press"


### PR DESCRIPTION
## Summary

- Remove redundant `call_soon_threadsafe` in `_handle_device_update` that caused race conditions during startup
- The callback is already dispatched to the event loop by PySrDaliGateway's `_dispatch_callback`, so calling `call_soon_threadsafe` again was unnecessary
- Add `@callback` decorator to `_handle_device_update` and execute event firing logic synchronously

Fixes #63

## Changes

- `event.py`: Simplify `_handle_device_update` by removing nested function and `call_soon_threadsafe`
- `pyproject.toml`: Add pytest infrastructure and mypy/pyright configurations
- `tests/`: Add unit tests for event handling to prevent regression

## Test plan

- [x] Run `pytest tests/test_event.py` - all tests should pass
- [x] Manual test: restart Home Assistant with Dali Center integration and verify no segfault occurs