### PR TITLE
fix(gateway): add semaphore to serialize concurrent initialization

### DIFF
--- a/custom_components/dali_center/manifest.json
+++ b/custom_components/dali_center/manifest.json
@@ -13,6 +13,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/maginawin/ha-dali-center/issues",
   "quality_scale": "bronze",
-  "requirements": ["PySrDaliGateway>=0.19.0,<0.20.0"],
+  "requirements": ["PySrDaliGateway>=0.19.1,<0.20.0"],
   "version": "0.11.2"
 }


### PR DESCRIPTION
## Summary

- Add `asyncio.Semaphore` to limit concurrent gateway connections (max 2)
- Prevents thundering herd problem causing Signal 11 crashes when multiple gateways initialize simultaneously
- Bump PySrDaliGateway requirement to 0.19.1

Ref #63

## Test plan

- [x] Test with single gateway configuration
- [x] Test with multiple (3+) gateways to verify serialized initialization
- [x] Verify no Signal 11 crashes during HA startup