### PR TITLE
refactor(entity): apply HA best practices to all platforms

### DIFF
--- a/custom_components/dali_center/button.py
+++ b/custom_components/dali_center/button.py
@@ -1,5 +1,7 @@
 """Support for Dali Center Gateway Control Buttons."""
 
+from __future__ import annotations
+
 import logging
 
 from PySrDaliGateway import CallbackEventType, DaliGateway, Device
@@ -8,6 +10,7 @@ from PySrDaliGateway.helper import is_light_device
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, MANUFACTURER
@@ -15,6 +18,8 @@ from .entity import DaliDeviceEntity
 from .types import DaliCenterConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1  # Serial button presses to prevent race conditions
 
 
 async def async_setup_entry(
@@ -52,9 +57,9 @@ class DaliCenterGatewayRestartButton(ButtonEntity):
         self._gateway = gateway
         self._attr_name = f"{gateway.name} Restart"
         self._attr_unique_id = f"{gateway.gw_sn}_restart"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, gateway.gw_sn)},
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, gateway.gw_sn)},
+        )
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added to hass."""
@@ -90,13 +95,13 @@ class DaliCenterDeviceIdentifyButton(DaliDeviceEntity, ButtonEntity):
         self._device = device
         self._attr_name = "Identify"
         self._attr_unique_id = f"{device.unique_id}_identify"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.dev_id)},
-            "name": device.name,
-            "manufacturer": MANUFACTURER,
-            "model": device.model,
-            "via_device": (DOMAIN, device.gw_sn),
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.dev_id)},
+            name=device.name,
+            manufacturer=MANUFACTURER,
+            model=device.model,
+            via_device=(DOMAIN, device.gw_sn),
+        )
 
     async def async_press(self) -> None:
         """Handle button press to identify device."""

--- a/custom_components/dali_center/event.py
+++ b/custom_components/dali_center/event.py
@@ -10,6 +10,7 @@ from PySrDaliGateway.types import PanelEventType, PanelStatus
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, MANUFACTURER
@@ -17,6 +18,8 @@ from .entity import DaliDeviceEntity
 from .types import DaliCenterConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0  # Read-only event entities, no concurrency limit needed
 
 
 async def async_setup_entry(
@@ -68,13 +71,13 @@ class DaliCenterPanelEvent(DaliDeviceEntity, EventEntity):
         self._attr_unique_id = f"{panel.dev_id}_panel_events"
 
         self._attr_event_types = panel.get_available_event_types()
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, panel.dev_id)},
-            "name": panel.name,
-            "manufacturer": MANUFACTURER,
-            "model": panel.model,
-            "via_device": (DOMAIN, panel.gw_sn),
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, panel.dev_id)},
+            name=panel.name,
+            manufacturer=MANUFACTURER,
+            model=panel.model,
+            via_device=(DOMAIN, panel.gw_sn),
+        )
 
     async def async_added_to_hass(self) -> None:
         """Handle when entity is added to hass."""

--- a/custom_components/dali_center/light.py
+++ b/custom_components/dali_center/light.py
@@ -22,6 +22,7 @@ from homeassistant.components.light import (
 from homeassistant.components.light.const import ColorMode
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -30,6 +31,8 @@ from .entity import DaliCenterEntity, DaliDeviceEntity
 from .types import DaliCenterConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1  # Serial control to prevent device overload
 
 
 async def async_setup_entry(
@@ -73,13 +76,13 @@ class DaliCenterLight(DaliDeviceEntity, LightEntity):
         super().__init__(light)
         self._light = light
         self._attr_name = "Light"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, light.dev_id)},
-            "name": light.name,
-            "manufacturer": MANUFACTURER,
-            "model": light.model,
-            "via_device": (DOMAIN, light.gw_sn),
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, light.dev_id)},
+            name=light.name,
+            manufacturer=MANUFACTURER,
+            model=light.model,
+            via_device=(DOMAIN, light.gw_sn),
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": light.gw_sn,
             "address": light.address,
@@ -196,9 +199,9 @@ class DaliCenterLightGroup(DaliCenterEntity, LightEntity):
         super().__init__(group)
         self._group = group
         self._attr_name = f"{group.name}"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, group.gw_sn)},
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, group.gw_sn)},
+        )
 
     @cached_property
     def _group_entity_ids(self) -> list[str]:
@@ -370,9 +373,9 @@ class DaliCenterAllLights(DaliDeviceEntity, LightEntity):
         super().__init__(controller)
         self._controller = controller
         self._config_entry_id = config_entry_id
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, controller.gw_sn)},
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, controller.gw_sn)},
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": controller.gw_sn,
             "address": controller.address,

--- a/custom_components/dali_center/number.py
+++ b/custom_components/dali_center/number.py
@@ -11,11 +11,14 @@ from PySrDaliGateway.types import DeviceParamType
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .entity import DaliDeviceEntity
 from .types import DaliCenterConfigEntry
+
+PARALLEL_UPDATES = 1  # Serial control to prevent race conditions
 
 
 async def async_setup_entry(
@@ -64,9 +67,9 @@ class DaliCenterDeviceParameterNumber(DaliDeviceEntity, NumberEntity):
         self._attr_name = name
         self._attr_icon = icon
         self._attr_unique_id = f"{device.unique_id}_{parameter}"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.dev_id)},
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.dev_id)},
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": device.gw_sn,
             "address": device.address,

--- a/custom_components/dali_center/scene.py
+++ b/custom_components/dali_center/scene.py
@@ -1,5 +1,7 @@
 """Support for DALI Center Scene entities."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 

--- a/custom_components/dali_center/sensor.py
+++ b/custom_components/dali_center/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import LIGHT_LUX, EntityCategory, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -29,6 +30,8 @@ from .entity import DaliDeviceEntity
 from .types import DaliCenterConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0  # Read-only sensors, no concurrency limit needed
 
 
 async def async_setup_entry(
@@ -68,9 +71,9 @@ class DaliCenterEnergySensor(DaliDeviceEntity, SensorEntity):
         self._device = device
         self._attr_unique_id = f"{device.unique_id}_energy"
         self._attr_native_value = 0.0
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.dev_id)},
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.dev_id)},
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": device.gw_sn,
             "address": device.address,
@@ -109,13 +112,13 @@ class DaliCenterMotionSensor(DaliDeviceEntity, SensorEntity):
         super().__init__(device)
         self._device = device
         self._attr_native_value = "no_motion"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.dev_id)},
-            "name": device.name,
-            "manufacturer": MANUFACTURER,
-            "model": device.model,
-            "via_device": (DOMAIN, device.gw_sn),
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.dev_id)},
+            name=device.name,
+            manufacturer=MANUFACTURER,
+            model=device.model,
+            via_device=(DOMAIN, device.gw_sn),
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": device.gw_sn,
             "address": device.address,
@@ -157,13 +160,13 @@ class DaliCenterIlluminanceSensor(DaliDeviceEntity, SensorEntity):
         self._device = device
         self._attr_native_value: StateType | date | datetime | Decimal = None
         self._sensor_enabled: bool = True
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.dev_id)},
-            "name": device.name,
-            "manufacturer": MANUFACTURER,
-            "model": device.model,
-            "via_device": (DOMAIN, device.gw_sn),
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.dev_id)},
+            name=device.name,
+            manufacturer=MANUFACTURER,
+            model=device.model,
+            via_device=(DOMAIN, device.gw_sn),
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": device.gw_sn,
             "address": device.address,

--- a/custom_components/dali_center/switch.py
+++ b/custom_components/dali_center/switch.py
@@ -11,6 +11,7 @@ from PySrDaliGateway.helper import is_illuminance_sensor
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, MANUFACTURER
@@ -18,6 +19,8 @@ from .entity import DaliDeviceEntity
 from .types import DaliCenterConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1  # Serial control to prevent race conditions
 
 
 async def async_setup_entry(
@@ -48,13 +51,13 @@ class DaliCenterIlluminanceSensorEnableSwitch(DaliDeviceEntity, SwitchEntity):
         self._device = device
         self._attr_unique_id = f"{device.dev_id}_sensor_enable"
         self._attr_is_on: bool | None = True
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.dev_id)},
-            "name": device.name,
-            "manufacturer": MANUFACTURER,
-            "model": device.model,
-            "via_device": (DOMAIN, device.gw_sn),
-        }
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.dev_id)},
+            name=device.name,
+            manufacturer=MANUFACTURER,
+            model=device.model,
+            via_device=(DOMAIN, device.gw_sn),
+        )
         self._attr_extra_state_attributes = {
             "gateway_sn": device.gw_sn,
             "address": device.address,


### PR DESCRIPTION
## Summary

- Use `DeviceInfo` class instead of dict for type safety and IDE support
- Add `PARALLEL_UPDATES` constant to all platform modules
- Add `from __future__ import annotations` imports where missing

## Changes

| File | DeviceInfo | PARALLEL_UPDATES | Import |
|------|------------|------------------|--------|
| sensor.py | 3 → class | `= 0` | - |
| light.py | 3 → class | `= 1` | - |
| button.py | 2 → class | `= 1` | `__future__` |
| switch.py | 1 → class | `= 1` | - |
| number.py | 1 → class | `= 1` | - |
| event.py | 1 → class | `= 0` | - |
| scene.py | (already) | (already) | `__future__` |

## Test plan

- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] `mypy custom_components/dali_center/` passes
- [x] Integration loads correctly in Home Assistant