### PR TITLE
fix(number)!: correct power_status and system_failure_status ranges

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -85,6 +85,7 @@ jobs:
         uses: ludeeus/setup-homeassistant@main
         with:
           config-dir: ./test_config
+          tag: stable
 
   validate-hacs:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -80,12 +80,12 @@ jobs:
           echo "  logs:" >> $config_path/configuration.yaml
           echo "    custom_components.dali_center: debug" >> $config_path/configuration.yaml
 
-      - name: Setup Home Assistant
-        id: homeassistant
-        uses: ludeeus/setup-homeassistant@main
-        with:
-          config-dir: ./test_config
-          tag: stable
+      - name: Validate with Home Assistant
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}/test_config:/config \
+            ghcr.io/home-assistant/home-assistant:stable \
+            /bin/bash -c "hass --script check_config -c /config"
 
   validate-hacs:
     runs-on: "ubuntu-latest"

--- a/custom_components/dali_center/config_flow.py
+++ b/custom_components/dali_center/config_flow.py
@@ -103,8 +103,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ("fade_rate", 0, 15),
             ("min_brightness", 10, 1000),
             ("max_brightness", 10, 1000),
-            ("power_status", 10, 1000),
-            ("system_failure_status", 0, 254),
+            ("power_status", 0, 255),
+            ("system_failure_status", 0, 255),
             ("cct_cool", 1000, 10000),
             ("cct_warm", 1000, 10000),
         ]

--- a/custom_components/dali_center/number.py
+++ b/custom_components/dali_center/number.py
@@ -220,8 +220,8 @@ class DaliCenterPowerOnLevelNumber(DaliCenterDeviceParameterNumber):
             parameter="power_status",
             name="Power On Level",
             icon="mdi:power-on",
-            min_value=10,
-            max_value=1000,
+            min_value=0,
+            max_value=255,
         )
 
 
@@ -236,7 +236,7 @@ class DaliCenterSystemFailureLevelNumber(DaliCenterDeviceParameterNumber):
             name="System Failure Level",
             icon="mdi:alert-outline",
             min_value=0,
-            max_value=254,
+            max_value=255,
         )
 
 

--- a/custom_components/dali_center/translations/en.json
+++ b/custom_components/dali_center/translations/en.json
@@ -224,8 +224,8 @@
                     "fade_rate": "Fade rate (0-15)",
                     "min_brightness": "Min brightness (10-1000) (≈1%-100%)",
                     "max_brightness": "Max brightness (10-1000) (≈1%-100%)",
-                    "power_status": "Power on level (10-1000) (≈1%-100%)",
-                    "system_failure_status": "System failure level (0-254)",
+                    "power_status": "Power on level (0-255, 255=MASK)",
+                    "system_failure_status": "System failure level (0-255, 255=MASK)",
                     "cct_cool": "CCT coolest (1000-10000 K)",
                     "cct_warm": "CCT warmest (1000-10000 K)"
                 }

--- a/tests/test_number_config.py
+++ b/tests/test_number_config.py
@@ -51,8 +51,8 @@ class TestPowerOnLevelEntity:
         entity = DaliCenterPowerOnLevelNumber(_make_device())
         assert entity._attr_name == "Power On Level"
         assert entity._attr_icon == "mdi:power-on"
-        assert entity._attr_native_min_value == 10
-        assert entity._attr_native_max_value == 1000
+        assert entity._attr_native_min_value == 0
+        assert entity._attr_native_max_value == 255
 
     def test_read_power_status(self) -> None:
         """Entity should update native_value from DEV_PARAM callback."""
@@ -81,10 +81,31 @@ class TestPowerOnLevelEntity:
         entity = DaliCenterPowerOnLevelNumber(device)
         entity.hass = MagicMock()
 
-        await entity.async_set_native_value(800)
+        await entity.async_set_native_value(200)
 
-        device.set_device_parameters.assert_called_once_with({"power_status": 800})
+        device.set_device_parameters.assert_called_once_with({"power_status": 200})
         device.get_device_parameters.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_mask_value(self) -> None:
+        """Setting 255 (MASK) should send 255 to device."""
+        device = _make_device()
+        entity = DaliCenterPowerOnLevelNumber(device)
+        entity.hass = MagicMock()
+
+        await entity.async_set_native_value(255)
+
+        device.set_device_parameters.assert_called_once_with({"power_status": 255})
+
+    def test_read_mask_value(self) -> None:
+        """Entity should correctly read back MASK value (255)."""
+        entity = DaliCenterPowerOnLevelNumber(_make_device())
+        entity.hass = MagicMock()
+
+        with patch.object(entity, "schedule_update_ha_state"):
+            entity._handle_device_parameters({"power_status": 255})
+
+        assert entity._attr_native_value == 255
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +120,7 @@ class TestSystemFailureLevelEntity:
         assert entity._attr_name == "System Failure Level"
         assert entity._attr_icon == "mdi:alert-outline"
         assert entity._attr_native_min_value == 0
-        assert entity._attr_native_max_value == 254
+        assert entity._attr_native_max_value == 255
 
     def test_read_system_failure_status(self) -> None:
         """Entity should update native_value from DEV_PARAM callback."""
@@ -123,6 +144,29 @@ class TestSystemFailureLevelEntity:
         device.set_device_parameters.assert_called_once_with(
             {"system_failure_status": 0}
         )
+
+    @pytest.mark.asyncio
+    async def test_set_mask_value(self) -> None:
+        """Setting 255 (MASK) should send 255 to device."""
+        device = _make_device()
+        entity = DaliCenterSystemFailureLevelNumber(device)
+        entity.hass = MagicMock()
+
+        await entity.async_set_native_value(255)
+
+        device.set_device_parameters.assert_called_once_with(
+            {"system_failure_status": 255}
+        )
+
+    def test_read_mask_value(self) -> None:
+        """Entity should correctly read back MASK value (255)."""
+        entity = DaliCenterSystemFailureLevelNumber(_make_device())
+        entity.hass = MagicMock()
+
+        with patch.object(entity, "schedule_update_ha_state"):
+            entity._handle_device_parameters({"system_failure_status": 255})
+
+        assert entity._attr_native_value == 255
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **BREAKING**: Power On Level range 10-1000 → 0-255, System Failure Level range 0-254 → 0-255
- 255 = DALI MASK (keep current state), labels updated with "(255=MASK)" hint
- Batch configure validation ranges synced
- MASK (255) test cases added for both parameters

## Breaking Change

Existing automations using old range values (e.g. `power_on_level: 500`) must be updated to the new 0-255 range.

## Test plan

- [x] `ruff check` + `ruff format --check` passed
- [x] 75 unit tests passed (`pytest tests/`)
- [x] Hardware test on real gateway confirmed MASK (255) write/readback works

Related: #79
Depends on: maginawin/PySrDaliGateway#48